### PR TITLE
fix: use auth when getting activity

### DIFF
--- a/scripts/activity.js
+++ b/scripts/activity.js
@@ -2,7 +2,9 @@ const { Octokit } = require('@octokit/rest');
 const { writeFile } = require('fs-extra');
 const path = require('path');
 
-const octokit = new Octokit();
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN 
+});
 
 (async () => {
   const response = await octokit.activity.listPublicEventsForUser({


### PR DESCRIPTION
Source: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret.